### PR TITLE
fixed the stacked bar plot so that only unique flights are counted

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -159,12 +159,13 @@ def __avg_delay(delay_times: np.ndarray) -> float:
     return 0
 
   
-def plot_stacked(df):
+def _plot_stacked(df):
     _filtered_df = df.copy()
     _filtered_df['DAY_OF_WEEK'] = pd.to_datetime(_filtered_df['FL_DATE']).dt.day_name().apply(lambda x: x[:3])
+    _filtered_df['FLIGHT_ID'] = _filtered_df['AIRLINE'] + '-' + _filtered_df['AIRLINE_CODE']
     plot_data = (_filtered_df.groupby(['DAY_OF_WEEK', 'AIRLINE_CODE'])
-                               .size()
-                               .reset_index(name='FLIGHT_COUNT'))
+                               .agg(FLIGHT_COUNT=('FLIGHT_ID', 'nunique'))
+                               .reset_index())
     chart = alt.Chart(plot_data).mark_bar().encode(
         x='DAY_OF_WEEK:O',  # Ordinal data
         y='FLIGHT_COUNT:Q',  # Quantitative data
@@ -353,7 +354,7 @@ def cb(origin_dropdown, dest_dropdown, year_range):
 
     bar_plot = _plot_bar_plot(_df)
     hist_plot = _plot_hist_plot(_df)
-    stacked_bar_plot = plot_stacked(_df)
+    stacked_bar_plot = _plot_stacked(_df)
     map_plot = _plot_map(origin_dropdown, dest_dropdown, cities_lat_long)
 
     return pct_flights_on_time, avg_flight_time, avg_delay, bar_plot, stacked_bar_plot, hist_plot, map_plot


### PR DESCRIPTION
The stacked bar plot by day of the week looks like the picture below:

<img width="479" alt="Screenshot 2024-04-06 at 8 14 40 PM" src="https://github.com/UBC-MDS/DSCI-532_2024_22_flightfinder/assets/35076573/9c1e3799-2f69-4f53-a4bb-255feeb27b40">

Most of the time each airline has exactly 1 unique flight from origin to destination, which makes sense. And sometimes certain airline has no flight available on certain days (like NK does not have any flight on Wednesday).