### PR TITLE
fix: handle None values when filtering by index and prevent charts

### DIFF
--- a/src/callbacks.py
+++ b/src/callbacks.py
@@ -58,7 +58,11 @@ def cb(origin_dropdown, dest_dropdown, year_range):
     if isinstance(dest_dropdown, list):
         dest_dropdown = dest_dropdown[0]
 
-    _df = df.loc[(origin_dropdown, dest_dropdown, year_range), :].copy()
+    origin = origin_dropdown if origin_dropdown is not None else slice(None)
+    destination = dest_dropdown if dest_dropdown is not None else slice(None)
+    year = year_range if year_range is not None else slice(None)
+
+    _df = df.loc[(origin, destination, year), :].copy()
     _df.reset_index(inplace=True)
 
     # flights on time
@@ -89,9 +93,15 @@ def cb(origin_dropdown, dest_dropdown, year_range):
                  dbc.CardBody(f'{int(tmp_avg_delay)}min', style={'textAlign': 'center',
                                                                  'fontSize': '40px'})] # card to return
 
-    bar_plot = plot_bar_plot(_df)
-    hist_plot = plot_hist_plot(_df)
-    stacked_bar_plot = plot_stacked(_df)
+    if origin_dropdown is not None and dest_dropdown is not None:
+        bar_plot = plot_bar_plot(_df)
+        hist_plot = plot_hist_plot(_df)
+        stacked_bar_plot = plot_stacked(_df)
+    else:
+        bar_plot = None
+        hist_plot = None
+        stacked_bar_plot = None
+
     map_plot = plot_map(origin_dropdown, dest_dropdown, cities_lat_long)
 
     return pct_flights_on_time, _avg_flight_time, _avg_delay, bar_plot, stacked_bar_plot, hist_plot, map_plot


### PR DESCRIPTION
- All changes were made in the callbacks.py file
- Made the index filtering mechanism more flexible to enable None types when a dropdown option isn't chosen
- This leads to very large datasets if unfiltered, so I edited to only display charts when all dropdowns have values